### PR TITLE
ci: rename unit test to lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Unit Test
+name: Lint
 
 on:
   push:


### PR DESCRIPTION
目前 `unit-text.yml` 只干了 lint 的事，取名为 `lint.yml` 更合适