### PR TITLE
fix: giscus repo id

### DIFF
--- a/src/components/episode-content.vue
+++ b/src/components/episode-content.vue
@@ -28,7 +28,7 @@ const episode = $computed(() => episodes.find((episode) => episode.id === id))
       <Giscus
         id="comments"
         repo="opensource-f2f/website"
-        repo-id="R_kgDOH62a3Q="
+        repo-id="R_kgDOH62a3Q"
         category="General"
         category-id="DIC_kwDOH62a3c4CR4dr"
         mapping="pathname"


### PR DESCRIPTION
It works well after this PR.

![image](https://user-images.githubusercontent.com/1450685/202346609-6ed67ed7-e069-4d3a-b32b-4e50e6eea7cf.png)
