### PR TITLE
refactor: embed audio using `<audio>` element

### DIFF
--- a/src/components/episode-content.vue
+++ b/src/components/episode-content.vue
@@ -9,6 +9,12 @@ const { id } = defineProps<{ id: string }>()
 
 const episode = $computed(() => episodes.find((episode) => episode.id === id))
 
+function isAudio(url) {
+  const audioFormats = ['mp3', 'm4a']
+
+  return audioFormats.some((format) => url.endsWith(`.${format}`))
+}
+
 if (episode)
   useHead({
     title: episode.title,
@@ -34,10 +40,16 @@ if (episode)
   <div v-if="episode" container mx-auto px-4 mt-5>
     <div mb-5>
       <h1 text-center text-2xl font-bold mb-2 v-html="episode.title" />
-      <div flex justify-center my-2>
-        <a :href="episode.link" target="_blank" text-black dark:text-white>
-          <div i-fluent:headphones-sound-wave-24-filled text-xl />
-        </a>
+      <div v-if="isAudio(episode.link)">
+        <figure box-border my-2>
+          <audio
+            controls
+            :src="episode.link"
+            style="width: 100%; min-width: 300px"
+          >
+            Your browser does not support the <code>audio</code> element.
+          </audio>
+        </figure>
       </div>
 
       <episode-meta :info="episode" justify-center />


### PR DESCRIPTION
## When can merge this PR?

Wait for opensource-f2f/episode#209 merged.

## What has been modified by this PR?

<table>
<tr>
	<td>before
	<td> after
<tr>
	<td> <img width="584" alt="image" src="https://user-images.githubusercontent.com/36906329/226907618-368d82ba-8495-4771-9528-db939c2cd0a2.png">
	<td> <img width="1920" alt="image" src="https://user-images.githubusercontent.com/36906329/226907764-e9e3fb34-ba56-47ae-9cac-fefcb2fe9f1f.png">

</table>

Embed audio resources into web pages using the HTML [<audio>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio) attribute.

Discussed in the [comment of opensource-f2f/episode#209](https://github.com/opensource-f2f/episode/pull/209#discussion_r1141041588).

